### PR TITLE
feat:チャットプロンプトにウェブ検索機能を追加する

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -54,7 +54,9 @@ export async function POST(request: NextRequest) {
     );
 
     // ウェブ検索が有効な場合の設定
-    const completionConfig: any = {
+    const completionConfig: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming & {
+      tools?: Array<{ type: string }>;
+    } = {
       model: model,
       messages: [
         {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     const useMaxCompletionTokens = /^(gpt-4o|gpt-4o-mini|o4-mini|o3-mini)/.test(
       model
     );
-    
+
     // ウェブ検索が有効な場合の設定
     const completionConfig: any = {
       model: model,

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -11,6 +11,7 @@ export async function POST(request: NextRequest) {
       quotedMessage,
       quotedText,
       model = 'gpt-4o-mini',
+      webSearchEnabled = false,
       locale = 'en', // デフォルトは英語
     } = await request.json();
 
@@ -51,8 +52,9 @@ export async function POST(request: NextRequest) {
     const useMaxCompletionTokens = /^(gpt-4o|gpt-4o-mini|o4-mini|o3-mini)/.test(
       model
     );
-    // Enable streaming
-    const stream = await openai.chat.completions.create({
+    
+    // ウェブ検索が有効な場合の設定
+    const completionConfig: any = {
       model: model,
       messages: [
         {
@@ -68,7 +70,14 @@ export async function POST(request: NextRequest) {
       ...(useMaxCompletionTokens
         ? { max_completion_tokens: 4000 }
         : { max_tokens: 1000, temperature: 0.7 }),
-    });
+    };
+
+    // ウェブ検索が有効な場合、ツールを追加
+    if (webSearchEnabled) {
+      completionConfig.tools = [{ type: 'web_search' }];
+    }
+
+    const stream = await openai.chat.completions.create(completionConfig);
 
     let fullContent = '';
     let usage = null;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -807,14 +807,14 @@ body.no-scroll {
   user-select: none;
 }
 
-.web-search-checkbox input[type="checkbox"] {
+.web-search-checkbox input[type='checkbox'] {
   width: 16px;
   height: 16px;
   margin: 0;
   cursor: pointer;
 }
 
-.web-search-checkbox input[type="checkbox"]:disabled {
+.web-search-checkbox input[type='checkbox']:disabled {
   cursor: not-allowed;
   opacity: 0.6;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -796,6 +796,33 @@ body.no-scroll {
   cursor: not-allowed;
 }
 
+/* ウェブ検索チェックボックス */
+.web-search-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.web-search-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  cursor: pointer;
+}
+
+.web-search-checkbox input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.web-search-checkbox span {
+  line-height: 1;
+}
+
 .chat-input-wrapper textarea {
   flex: 1;
   min-height: 60px;

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -315,6 +315,7 @@ export default function ChatArea({
   const [selectedText, setSelectedText] = useState<string>('');
   const [justDeselected, setJustDeselected] = useState(false);
   const [selectedModel, setSelectedModel] = useState('o4-mini');
+  const [webSearchEnabled, setWebSearchEnabled] = useState(false);
   const [sendBehavior, setSendBehavior] = useState<'enter' | 'shift-enter'>(
     'enter'
   );
@@ -342,6 +343,9 @@ export default function ChatArea({
           }
           if (settings.sendBehavior) {
             setSendBehavior(settings.sendBehavior);
+          }
+          if (settings.webSearchEnabled !== undefined) {
+            setWebSearchEnabled(settings.webSearchEnabled);
           }
         }
       } catch (error) {
@@ -501,6 +505,24 @@ export default function ChatArea({
     }
   };
 
+  const handleWebSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const enabled = e.target.checked;
+    setWebSearchEnabled(enabled);
+
+    // Save to localStorage
+    try {
+      const savedSettings = localStorage.getItem('chatAppSettings');
+      let settings = {};
+      if (savedSettings) {
+        settings = JSON.parse(savedSettings);
+      }
+      settings = { ...settings, webSearchEnabled: enabled };
+      localStorage.setItem('chatAppSettings', JSON.stringify(settings));
+    } catch (error) {
+      console.error('Failed to save web search setting:', error);
+    }
+  };
+
   if (!conversation) {
     return (
       <section className="chat-area">
@@ -633,6 +655,15 @@ export default function ChatArea({
             style={{ resize: 'none', minHeight: '60px' }}
           />
           <div className="input-controls">
+            <label className="web-search-checkbox">
+              <input
+                type="checkbox"
+                checked={webSearchEnabled}
+                onChange={handleWebSearchChange}
+                disabled={isLoading}
+              />
+              <span>{t('webSearch')}</span>
+            </label>
             <select
               value={selectedModel}
               onChange={handleModelChange}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -203,16 +203,18 @@ export function useChat(conversationId: string | null) {
       let messagesForFallback = updatedMessages;
 
       try {
-        // 保存された設定からモデルを取得
+        // 保存された設定からモデルとウェブ検索設定を取得
         let selectedModel = 'o4-mini';
+        let webSearchEnabled = false;
         try {
           const savedSettings = localStorage.getItem('chatAppSettings');
           if (savedSettings) {
             const settings = JSON.parse(savedSettings);
             selectedModel = settings.aiModel || 'o4-mini';
+            webSearchEnabled = settings.webSearchEnabled || false;
           }
         } catch (error) {
-          console.error('Failed to load model setting:', error);
+          console.error('Failed to load settings:', error);
         }
 
         // AI応答を生成（ストリーミング対応）
@@ -257,6 +259,7 @@ export function useChat(conversationId: string | null) {
             quotedMessage,
             quotedText,
             model: selectedModel,
+            webSearchEnabled,
             locale,
           }),
         });

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -45,7 +45,8 @@
     "readMore": "Read more",
     "quoteAll": "Quote All",
     "quoteSelected": "Quote Selection",
-    "research": "Research"
+    "research": "Research",
+    "webSearch": "Web Search"
   },
   "tree": {
     "title": "Conversation Tree",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -45,7 +45,8 @@
     "readMore": "続きを読む",
     "quoteAll": "全体を引用",
     "quoteSelected": "選択部分を引用",
-    "research": "調べる"
+    "research": "調べる",
+    "webSearch": "ウェブ検索"
   },
   "tree": {
     "title": "会話ツリー",


### PR DESCRIPTION
課題#25で要求されたウェブ検索機能を追加。

## 変更点
- モデル選択の上にウェブ検索チェックボックスを追加
- localStorageを使った永続的な設定の実装
- OpenAI ウェブ検索ツール API を統合
- バイリンガル翻訳の追加 (EN/JA)
- 一貫した CSS スタイリングの追加

## テスト
1.モデル選択の上にあるウェブ検索チェックボックスをチェックする
2.最近の出来事について尋ねるメッセージを送る
3.AIがウェブを検索し、最新の情報を提供できることを確認する。

25を解決

クロードコード](https://claude.ai/code)で生成。